### PR TITLE
Update ActiveRecord adapter w/ support for Rails 7.2+

### DIFF
--- a/lib/graphiti/adapters/active_record.rb
+++ b/lib/graphiti/adapters/active_record.rb
@@ -304,7 +304,11 @@ module Graphiti
       end
 
       def close
-        ::ActiveRecord::Base.clear_active_connections!
+        if ::ActiveRecord.version > 7.2
+          ::ActiveRecord::Base.connection_handler.clear_active_connections!
+        else
+          ::ActiveRecord::Base.clear_active_connections!
+        end
       end
 
       def can_group?


### PR DESCRIPTION
In ActiveRecord 7.2 the `clear_active_connections` was (re)moved to the `connection_handler` property.